### PR TITLE
Fixes for latest OF master and GL 3+

### DIFF
--- a/Core/src/ofxRulr/Utils/SoundEngine.cpp
+++ b/Core/src/ofxRulr/Utils/SoundEngine.cpp
@@ -12,8 +12,15 @@ namespace ofxRulr {
 			auto devices = this->soundStream.getDeviceList();
 			for (auto & device : devices) {
 				if (device.isDefaultOutput) {
-					this->soundStream.setDevice(device);
-					this->soundStream.setup(2, 0, 44100, 1024, 1);
+					ofSoundStreamSettings settings;
+					settings.setOutDevice(device);
+					settings.bufferSize = 1024;
+					settings.numBuffers = 1;
+					settings.numOutputChannels = 2;
+					settings.numInputChannels = 0;
+					settings.sampleRate = 44100;
+					this->soundStream.setup(settings);
+					break;
 				}
 			}
 			//if that didn't work
@@ -22,8 +29,14 @@ namespace ofxRulr {
 			if (!success) {
 				for (auto & device : devices) {
 					if (device.outputChannels >= 2) {
-						this->soundStream.setDevice(device);
-						this->soundStream.setup(2, 0, 44100, 1024, 1);
+						ofSoundStreamSettings settings;
+						settings.setOutDevice(device);
+						settings.bufferSize = 1024;
+						settings.numBuffers = 1;
+						settings.numOutputChannels = 2;
+						settings.numInputChannels = 0;
+						settings.sampleRate = 44100;
+						this->soundStream.setup(settings);
 						success = true;
 						break;
 					}

--- a/Nodes/src/ofxRulr/Nodes/System/VideoOutput.cpp
+++ b/Nodes/src/ofxRulr/Nodes/System/VideoOutput.cpp
@@ -431,24 +431,22 @@ namespace ofxRulr {
 				//draw the fbo if mute is disabled
 				if (!this->mute) {
 					//set the drawing matrices to normalised coordinates
-					glMatrixMode(GL_PROJECTION);
-					glPushMatrix();
-					glLoadIdentity();
-					glMatrixMode(GL_MODELVIEW);
-					glPushMatrix();
-					glLoadIdentity();
+					ofSetMatrixMode(OF_MATRIX_PROJECTION);
+					ofPushMatrix();
+					ofLoadMatrix(ofMatrix4x4());
+					ofSetMatrixMode(OF_MATRIX_MODELVIEW);
+					ofPushMatrix();
+					ofLoadMatrix(ofMatrix4x4());
 
 					this->fbo.draw(-1, +1, 2, -2);
 
 					//reset all transforms
-					glMatrixMode(GL_PROJECTION);
-					glPopMatrix();
-					glMatrixMode(GL_MODELVIEW);
-					glPopMatrix();
+					ofSetMatrixMode(OF_MATRIX_PROJECTION);
+					ofPopMatrix();
+					ofSetMatrixMode(OF_MATRIX_MODELVIEW);
+					ofPopMatrix();
 				}
 
-
-				// TODO: add swap buffers method to window
 				this->window->swapBuffers();
 
 				//return to main window


### PR DESCRIPTION
the soundStream api has changed, this fixes SoundEngine to work with
the new ofSoundStreamSettings

in videooutput when drawing to a second context it would use glLoadMatrix
glPushMatrix... which don't exist anymore in GL 3+

i think there were some changes in the break lines and the diff is not very clear in VideoOutput but the only thing that really changed was:

``` diff
-               if (!this->mute) {
-                   //set the drawing matrices to normalised coordinates
-                   glMatrixMode(GL_PROJECTION);
-                   glPushMatrix();
-                   glLoadIdentity();
-                   glMatrixMode(GL_MODELVIEW);
-                   glPushMatrix();
-                   glLoadIdentity();
-
-                   this->fbo.draw(-1, +1, 2, -2);
-
-                   //reset all transforms
-                   glMatrixMode(GL_PROJECTION);
-                   glPopMatrix();
-                   glMatrixMode(GL_MODELVIEW);
-                   glPopMatrix();
-               }
```

to

``` cpp

                if (!this->mute) {
                    //set the drawing matrices to normalised coordinates
                    ofSetMatrixMode(OF_MATRIX_PROJECTION);
                    ofPushMatrix();
                    ofLoadMatrix(ofMatrix4x4());
                    ofSetMatrixMode(OF_MATRIX_MODELVIEW);
                    ofPushMatrix();
                    ofLoadMatrix(ofMatrix4x4());

                    this->fbo.draw(-1, +1, 2, -2);

                    //reset all transforms
                    ofSetMatrixMode(OF_MATRIX_PROJECTION);
                    ofPopMatrix();
                    ofSetMatrixMode(OF_MATRIX_MODELVIEW);
                    ofPopMatrix();
                }
```
