### PR TITLE
Add Unity camera import script (contributed by Nick Fox-Gieg)

### DIFF
--- a/Nodes/src/ofxRulr/Nodes/Item/View.cpp
+++ b/Nodes/src/ofxRulr/Nodes/Item/View.cpp
@@ -219,6 +219,13 @@ namespace ofxRulr {
 					RULR_CATCH_ALL_TO_ALERT
 				}));
 
+				inspector->add(new Widgets::Button("Export for Unity...", [this]() {
+					try {
+						this->exportForUnity();
+					}
+					RULR_CATCH_ALL_TO_ALERT
+				}));
+
 				inspector->add(make_shared<Widgets::Spacer>());
 			}
 
@@ -389,6 +396,39 @@ namespace ofxRulr {
 						fs << "translation" << translation;
 						fs << "rotationMatrix" << rotationMatrix;
 					}
+				}
+			}
+
+			//----------
+			void View::exportForUnity() {
+				auto result = ofSystemSaveDialog(this->getName() + "-Unity.json", "Export Camera for Unity");
+				if (result.bSuccess) {
+					const auto view = this->getViewInWorldSpace();
+
+					// Standalone JSON export for use with the Unity RulrImport.cs editor script
+					// (see PlatformExamples/Unity/). Unlike the shared DECLARE_SERIALIZE_GLM_MAT
+					// serializer used for node persistence (which nests each matrix as 4 arrays
+					// of 4 floats), Unity's Matrix4x4 flat indexer expects a single flat array of
+					// 16 floats in column-major order (matrix[col][row]), matching glm's native
+					// column-major / OpenGL storage order.
+					auto flattenColumnMajor = [](const glm::mat4 & matrix) {
+						nlohmann::json jsonMatrix = nlohmann::json::array();
+						for (int col = 0; col < 4; col++) {
+							for (int row = 0; row < 4; row++) {
+								jsonMatrix.push_back(matrix[col][row]);
+							}
+						}
+						return jsonMatrix;
+					};
+
+					nlohmann::json json;
+					auto & jsonOpenGL = json["OpenGL"];
+					jsonOpenGL["viewMatrix"] = flattenColumnMajor(view.getViewMatrix());
+					jsonOpenGL["projectionMatrix"] = flattenColumnMajor(view.getClippedProjectionMatrix());
+
+					ofstream fileout(ofToDataPath(result.filePath), ios::out);
+					fileout << json.dump(4);
+					fileout.close();
 				}
 			}
 

--- a/Nodes/src/ofxRulr/Nodes/Item/View.h
+++ b/Nodes/src/ofxRulr/Nodes/Item/View.h
@@ -49,6 +49,7 @@ namespace ofxRulr {
 				void exportProjectionMatrix();
 				void exportRayCamera();
 				void exportYaml();
+				void exportForUnity();
 
 				ofParameter<float> focalLengthX, focalLengthY;
 				ofParameter<float> principalPointX, principalPointY;

--- a/PlatformExamples/Unity/RulrImport.cs
+++ b/PlatformExamples/Unity/RulrImport.cs
@@ -1,0 +1,198 @@
+﻿using Newtonsoft.Json;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public class RulrImport {
+	class CameraLoader
+	{
+		public class OpenGLLoader
+		{
+			public float[] projectionMatrix;
+			public float[] viewMatrix;
+		};
+
+		public OpenGLLoader OpenGL = new OpenGLLoader();
+	};
+
+	/// <summary>
+	/// Extract translation from transform matrix.
+	/// </summary>
+	/// <param name="matrix">Transform matrix. This parameter is passed by reference
+	/// to improve performance; no changes will be made to it.</param>
+	/// <returns>
+	/// Translation offset.
+	/// </returns>
+	public static Vector3 ExtractTranslationFromMatrix(ref Matrix4x4 matrix)
+	{
+		Vector3 translate;
+		translate.x = matrix.m03;
+		translate.y = matrix.m13;
+		translate.z = matrix.m23;
+		return translate;
+	}
+
+	/// <summary>
+	/// Extract rotation quaternion from transform matrix.
+	/// </summary>
+	/// <param name="matrix">Transform matrix. This parameter is passed by reference
+	/// to improve performance; no changes will be made to it.</param>
+	/// <returns>
+	/// Quaternion representation of rotation transform.
+	/// </returns>
+	public static Quaternion ExtractRotationFromMatrix(ref Matrix4x4 matrix)
+	{
+		Vector3 forward;
+		forward.x = matrix.m02;
+		forward.y = matrix.m12;
+		forward.z = matrix.m22;
+
+		Vector3 upwards;
+		upwards.x = matrix.m01;
+		upwards.y = matrix.m11;
+		upwards.z = matrix.m21;
+
+		return Quaternion.LookRotation(forward, upwards);
+	}
+
+	/// <summary>
+	/// Extract scale from transform matrix.
+	/// </summary>
+	/// <param name="matrix">Transform matrix. This parameter is passed by reference
+	/// to improve performance; no changes will be made to it.</param>
+	/// <returns>
+	/// Scale vector.
+	/// </returns>
+	public static Vector3 ExtractScaleFromMatrix(ref Matrix4x4 matrix)
+	{
+		Vector3 scale;
+		scale.x = new Vector4(matrix.m00, matrix.m10, matrix.m20, matrix.m30).magnitude;
+		scale.y = new Vector4(matrix.m01, matrix.m11, matrix.m21, matrix.m31).magnitude;
+		scale.z = new Vector4(matrix.m02, matrix.m12, matrix.m22, matrix.m32).magnitude;
+		return scale;
+	}
+
+	/// <summary>
+	/// Extract position, rotation and scale from TRS matrix.
+	/// </summary>
+	/// <param name="matrix">Transform matrix. This parameter is passed by reference
+	/// to improve performance; no changes will be made to it.</param>
+	/// <param name="localPosition">Output position.</param>
+	/// <param name="localRotation">Output rotation.</param>
+	/// <param name="localScale">Output scale.</param>
+	public static void DecomposeMatrix(ref Matrix4x4 matrix, out Vector3 localPosition, out Quaternion localRotation, out Vector3 localScale)
+	{
+		localPosition = ExtractTranslationFromMatrix(ref matrix);
+		localRotation = ExtractRotationFromMatrix(ref matrix);
+		localScale = ExtractScaleFromMatrix(ref matrix);
+	}
+
+	/// <summary>
+	/// Set transform component from TRS matrix.
+	/// </summary>
+	/// <param name="transform">Transform component.</param>
+	/// <param name="matrix">Transform matrix. This parameter is passed by reference
+	/// to improve performance; no changes will be made to it.</param>
+	public static void SetTransformFromMatrix(Transform transform, ref Matrix4x4 matrix)
+	{
+		transform.localPosition = ExtractTranslationFromMatrix(ref matrix);
+		transform.localRotation = ExtractRotationFromMatrix(ref matrix);
+		transform.localScale = ExtractScaleFromMatrix(ref matrix);
+	}
+
+
+	// EXTRAS!
+
+	/// <summary>
+	/// Identity quaternion.
+	/// </summary>
+	/// <remarks>
+	/// <para>It is faster to access this variation than <c>Quaternion.identity</c>.</para>
+	/// </remarks>
+	public static readonly Quaternion IdentityQuaternion = Quaternion.identity;
+	/// <summary>
+	/// Identity matrix.
+	/// </summary>
+	/// <remarks>
+	/// <para>It is faster to access this variation than <c>Matrix4x4.identity</c>.</para>
+	/// </remarks>
+	public static readonly Matrix4x4 IdentityMatrix = Matrix4x4.identity;
+
+	/// <summary>
+	/// Get translation matrix.
+	/// </summary>
+	/// <param name="offset">Translation offset.</param>
+	/// <returns>
+	/// The translation transform matrix.
+	/// </returns>
+	public static Matrix4x4 TranslationMatrix(Vector3 offset)
+	{
+		Matrix4x4 matrix = IdentityMatrix;
+		matrix.m03 = offset.x;
+		matrix.m13 = offset.y;
+		matrix.m23 = offset.z;
+		return matrix;
+	}
+
+	[MenuItem("CONTEXT/Camera/Load Rulr Camera...")]
+	private static void LoadCamera(MenuCommand command)
+	{
+		var result = EditorUtility.OpenFilePanel("Select camera json file", "", "json");
+		if(result.Length != 0)
+		{
+			var jsonEncoded = File.ReadAllText(result);
+			var cameraLoader = JsonConvert.DeserializeObject<CameraLoader>(jsonEncoded);
+
+			var camera = command.context as Camera;
+
+			var projectionMatrix = new Matrix4x4();
+			var viewMatrix = new Matrix4x4();
+			for (int i=0; i<16; i++)
+			{
+				projectionMatrix[i] = cameraLoader.OpenGL.projectionMatrix[i];
+				viewMatrix[i] = cameraLoader.OpenGL.viewMatrix[i];
+			}
+			
+			projectionMatrix[1, 1] = -projectionMatrix[1, 1];
+			projectionMatrix[2, 2] = -projectionMatrix[2, 2];
+			projectionMatrix[3, 2] = -projectionMatrix[3, 2];
+
+			//lens offset
+			projectionMatrix[0, 2] = -projectionMatrix[0, 2];
+			projectionMatrix[1, 2] = -projectionMatrix[1, 2];
+
+			camera.projectionMatrix = projectionMatrix;
+			var viewInverse = viewMatrix.inverse;
+
+			//rotation
+			viewInverse[0, 1] *= -1;
+			viewInverse[0, 2] *= -1;
+
+			viewInverse[1, 0] *= -1;
+			viewInverse[1, 1] *= -1;
+			viewInverse[1, 2] *= -1;
+
+			viewInverse[2, 1] *= -1;
+
+			//translation
+			viewInverse[1, 3] *= -1;
+
+			var rotateAboutX = Matrix4x4.identity;
+			rotateAboutX[0, 0] = +1;
+			rotateAboutX[1, 1] = -1;
+			rotateAboutX[2, 2] = -1;
+
+			var rotateAboutZ = Matrix4x4.identity;
+			rotateAboutZ[0, 0] = -1;
+			rotateAboutZ[1, 1] = -1;
+			rotateAboutZ[2, 2] = +1;
+			rotateAboutZ[3, 3] = +1;
+
+			viewInverse = rotateAboutX * viewInverse * rotateAboutZ;
+			var transform = camera.gameObject.transform;
+			SetTransformFromMatrix(transform, ref viewInverse);
+		}
+	}
+}

--- a/PlatformExamples/Unity/readme.md
+++ b/PlatformExamples/Unity/readme.md
@@ -1,0 +1,29 @@
+# Introduction
+
+`RulrImport.cs` is a Unity Editor script that lets you load a calibrated camera from ofxRulr straight into a Unity `Camera` component (position, rotation and projection matrix all included). It's contributed by Nick Fox-Gieg.
+
+Originally contributed by Nick Fox-Gieg ([@n1ckfg](https://github.com/n1ckfg), https://github.com/n1ckfg/ofxRulr).
+
+# Exporting a camera from ofxRulr
+
+* Select a `Item::View` (or `Item::Camera`) node in the inspector.
+* Click the `Export for Unity...` button and save the file, e.g. `MyCamera-Unity.json`.
+* This writes a small standalone JSON file shaped like:
+
+```json
+{ "OpenGL": { "projectionMatrix": [16 floats], "viewMatrix": [16 floats] } }
+```
+
+  Note this is a dedicated flat-array export, separate from the nested-array `"OpenGL"` block that also appears inside the regular node save files (`View_0.json` etc.) — `RulrImport.cs` expects the flat form, so use this button rather than a saved node file.
+
+# Installing/using in Unity
+
+* Add [Newtonsoft.Json for Unity](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@latest) to your project (`com.unity.nuget.newtonsoft-json`) — `RulrImport.cs` depends on it for JSON deserialization.
+* Copy `RulrImport.cs` into an `Editor` folder in your Unity project's `Assets`.
+* Select a `Camera` in the scene, right-click its component header (or use the component's ⋮ menu) and choose `Load Rulr Camera...`.
+* Pick the JSON file exported above. The camera's transform and projection matrix are updated to match ofxRulr's calibration.
+
+## Notes
+
+* The script also exposes generic `Matrix4x4` decomposition helpers (`ExtractTranslationFromMatrix`, `ExtractRotationFromMatrix`, `ExtractScaleFromMatrix`, `DecomposeMatrix`, `SetTransformFromMatrix`, `TranslationMatrix`) that are reusable outside the camera-loading context.
+* Unity's `Matrix4x4` flat indexer (`matrix[0..15]`) is column-major, matching OpenGL/glm's native storage order — the ofxRulr-side export writes floats in that same order.


### PR DESCRIPTION
## Summary

Brings in a Unity Editor integration contributed by **Nick Fox-Gieg** ([@n1ckfg](https://github.com/n1ckfg)), from his fork at https://github.com/n1ckfg/ofxRulr, commit [`0602937`](https://github.com/n1ckfg/ofxRulr/commit/060293777e52cfd4f722658c0bb44de458d3f725) ("unity", 2023-06-30). All credit for `RulrImport.cs` and its design goes to him — this PR just wires it up to a compatible export path on the ofxRulr side and adds docs.

- **`PlatformExamples/Unity/RulrImport.cs`** — Nick's script, copied byte-for-byte (verified via matching git blob hash) from his commit, at a path mirroring the existing `PlatformExamples/VVVV/` convention for third-party tool integrations. Committed separately with his authorship (`Nick Fox-Gieg <n1ckfg@users.noreply.github.com>` — his real email isn't on file anywhere I could find, so this uses the standard GitHub noreply-email format for his handle as a best-effort attribution; flagging that assumption here) and a `Co-authored-by` trailer.
- **`Nodes/src/ofxRulr/Nodes/Item/View.{h,cpp}`** — adds a new `exportForUnity()` method + "Export for Unity..." inspector button, following the exact structural pattern of the existing `exportProjectionMatrix()` / `exportRayCamera()` / `exportYaml()` exporters.
- **`PlatformExamples/Unity/readme.md`** — usage docs (lowercase filename, short-intro-plus-bullets style matching `Plugin_Experiments/readme.md`), with a prominent attribution line for Nick.

## Why a new exporter instead of changing the existing serializer

`RulrImport.cs` deserializes `OpenGL.projectionMatrix` / `OpenGL.viewMatrix` into a flat `float[16]` (via Unity's `Matrix4x4[0..15]` indexer, which is column-major — same order as `glm`/OpenGL).

The `"OpenGL"` block that `View::serialize()` already writes uses `Utils::serialize(glm::mat4)`, which is a **nested** 4×4 JSON array (`DECLARE_SERIALIZE_GLM_MAT` in `Core/src/ofxRulr/Utils/Serialization/oF.cpp`), and that block is only emitted as a side effect of the general node-persistence save file (bundled with many unrelated keys) — nothing reads it back in either. Reshaping that shared serializer's output format would be a global, hard-to-verify regression risk (it's used for all node persistence, not just cameras), so instead this PR adds a small, additive, self-contained `View::exportForUnity()` that writes its own standalone JSON file with each matrix flattened to 16 floats in column-major order — matching Unity's expected layout exactly, without touching Nick's C# or the shared serializer at all.

## ⚠️ Not build-verified

This is a Windows / Visual Studio / openFrameworks project and **no Windows build environment was available to verify this C++ compiles**. The new code closely mirrors the existing exporter methods' structure (signature, `ofSystemSaveDialog` usage, button registration, `nlohmann::json` usage), but **please do a local Windows build check before merging**, and double check:
- The flat float ordering (`matrix[col][row]`, column-major) actually produces a correct, unskewed camera when loaded in Unity — a subtle transposition here would silently produce a wrong-but-plausible-looking camera rather than an error.
- `glm::mat4::operator[]` column/row semantics match the assumption stated in the code comment.

## Note on repo history

This repo's git history was recently rewritten (filter-repo/BFG-style rewrite + force-push) to strip sensitive information. This branch is based on the **current, post-rewrite tip of `master`** as of this PR — not any pre-rewrite commit SHAs.

## Checklist for reviewer

- [ ] Local Windows build of `Nodes` compiles cleanly with the `View.cpp`/`View.h` changes
- [ ] `Export for Unity...` button appears in the `View` node inspector and produces a valid JSON file
- [ ] Exported JSON loads correctly in Unity via `RulrImport.cs`'s `Load Rulr Camera...` menu command, with correct position/rotation/projection (no skew/flip)
- [ ] Attribution wording/email for Nick Fox-Gieg is acceptable

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1eDsxVZSdbfeoC6UfY9eY)_